### PR TITLE
feat: Secure document sharing via Magic Link + OTP verification

### DIFF
--- a/backend/internal/application/services/magic_link_service.go
+++ b/backend/internal/application/services/magic_link_service.go
@@ -6,10 +6,13 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"math/big"
 	"net/mail"
 	"net/url"
 	"strings"
 	"time"
+
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/btouchard/ackify-ce/backend/internal/infrastructure/email"
 	"github.com/btouchard/ackify-ce/backend/pkg/logger"
@@ -22,6 +25,9 @@ type MagicLinkRepository interface {
 	GetByToken(ctx context.Context, token string) (*models.MagicLinkToken, error)
 	MarkAsUsed(ctx context.Context, token string, ip string, userAgent string) error
 	DeleteExpired(ctx context.Context) (int64, error)
+	IncrementOTPAttempts(ctx context.Context, token string) error
+	RevokeToken(ctx context.Context, tokenID int64) error
+	ListByDocAndPurpose(ctx context.Context, docID string, purpose string) ([]*models.MagicLinkToken, error)
 
 	LogAttempt(ctx context.Context, attempt *models.MagicLinkAuthAttempt) error
 	CountRecentAttempts(ctx context.Context, email string, since time.Time) (int, error)
@@ -405,9 +411,226 @@ func (s *MagicLinkService) CleanupExpiredTokens(ctx context.Context) (int64, err
 	return s.repo.DeleteExpired(ctx)
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
+// CreateDocumentShareLink creates a magic link protected by OTP for sharing a document.
+// Returns the link URL and the cleartext OTP (shown once to the admin).
+func (s *MagicLinkService) CreateDocumentShareLink(
+	ctx context.Context,
+	emailAddr string,
+	docID string,
+	validityDays int,
+	sharedBy string,
+	locale string,
+) (linkURL string, otp string, err error) {
+	// Normaliser l'email
+	emailAddr = strings.ToLower(strings.TrimSpace(emailAddr))
+
+	// Valider le format email
+	if _, err := mail.ParseAddress(emailAddr); err != nil {
+		return "", "", fmt.Errorf("invalid email format")
 	}
-	return b
+
+	if docID == "" {
+		return "", "", fmt.Errorf("document ID is required")
+	}
+
+	// Validate and cap validity
+	if validityDays <= 0 {
+		validityDays = 7 // Default: 7 days
+	}
+	if validityDays > 90 {
+		validityDays = 90 // Max: 90 days
+	}
+
+	// Generate secure token for the URL
+	token, err := s.generateSecureToken()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate token: %w", err)
+	}
+
+	// Generate 6-digit OTP
+	otp, err = s.generateOTP()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate OTP: %w", err)
+	}
+
+	// Hash OTP with bcrypt
+	otpHashBytes, err := bcrypt.GenerateFromPassword([]byte(otp), bcrypt.DefaultCost)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to hash OTP: %w", err)
+	}
+	otpHash := string(otpHashBytes)
+
+	// Create token in DB
+	magicToken := &models.MagicLinkToken{
+		Token:              token,
+		Email:              emailAddr,
+		ExpiresAt:          time.Now().Add(time.Duration(validityDays) * 24 * time.Hour),
+		RedirectTo:         "/?doc=" + docID,
+		CreatedByIP:        "127.0.0.1", // System-initiated
+		CreatedByUserAgent: "admin-share",
+		Purpose:            "document_share",
+		DocID:              &docID,
+		OTPHash:            &otpHash,
+		OTPAttempts:        0,
+		OTPMaxAttempts:     5,
+		SharedBy:           &sharedBy,
+	}
+
+	if err := s.repo.CreateToken(ctx, magicToken); err != nil {
+		return "", "", fmt.Errorf("failed to create document share token: %w", err)
+	}
+
+	// Build the magic link URL
+	link := fmt.Sprintf("%s/api/v1/auth/document-share/verify?token=%s", s.baseURL, token)
+
+	// Send email to recipient (link only, no OTP)
+	if locale == "" {
+		locale = "en"
+	}
+
+	subject := "A document has been shared with you"
+	if s.i18n != nil {
+		subject = s.i18n.T(locale, "email.document_share.subject")
+	}
+
+	msg := email.Message{
+		To:       []string{emailAddr},
+		Subject:  subject,
+		Template: "document_share",
+		Locale:   locale,
+		Data: map[string]interface{}{
+			"AppName":      s.appName,
+			"Email":        emailAddr,
+			"ShareLink":    link,
+			"ValidityDays": validityDays,
+			"BaseURL":      s.baseURL,
+		},
+	}
+
+	if err := s.emailSender.Send(ctx, msg); err != nil {
+		logger.Logger.Error("Failed to send document share email", "error", err, "email", emailAddr)
+		// Don't fail the share creation if email fails — admin has the link
+	}
+
+	logger.Logger.Info("Document share link created",
+		"email", emailAddr,
+		"doc_id", docID,
+		"shared_by", sharedBy,
+		"validity_days", validityDays)
+
+	return link, otp, nil
+}
+
+// ValidateDocumentShareToken checks if a document share token exists and is valid.
+// This is a read-only check: it does NOT verify OTP or modify attempt counters.
+func (s *MagicLinkService) ValidateDocumentShareToken(ctx context.Context, token string) error {
+	magicToken, err := s.repo.GetByToken(ctx, token)
+	if err != nil {
+		return fmt.Errorf("invalid token")
+	}
+
+	if magicToken.Purpose != "document_share" {
+		return fmt.Errorf("invalid token type")
+	}
+
+	if !magicToken.IsValid() {
+		if magicToken.RevokedAt != nil {
+			return fmt.Errorf("share has been revoked")
+		}
+		if magicToken.IsOTPLocked() {
+			return fmt.Errorf("share is locked")
+		}
+		return fmt.Errorf("share has expired")
+	}
+
+	return nil
+}
+
+// VerifyDocumentShareOTP verifies the OTP for a document share token.
+// Unlike standard magic links, document_share tokens are multi-use.
+func (s *MagicLinkService) VerifyDocumentShareOTP(
+	ctx context.Context,
+	token string,
+	otpInput string,
+	ip string,
+	userAgent string,
+) (*models.MagicLinkToken, error) {
+	// Get the token
+	magicToken, err := s.repo.GetByToken(ctx, token)
+	if err != nil {
+		if len(token) > 8 {
+			logger.Logger.Warn("Document share token not found", "token_prefix", token[:8])
+		} else {
+			logger.Logger.Warn("Document share token not found", "token_prefix", token)
+		}
+		return nil, fmt.Errorf("invalid token")
+	}
+
+	// Check purpose
+	if magicToken.Purpose != "document_share" {
+		logger.Logger.Warn("Token is not a document_share token", "purpose", magicToken.Purpose)
+		return nil, fmt.Errorf("invalid token type")
+	}
+
+	// Check validity (expiry, revocation, OTP lockout)
+	if !magicToken.IsValid() {
+		if magicToken.RevokedAt != nil {
+			return nil, fmt.Errorf("share has been revoked")
+		}
+		if magicToken.IsOTPLocked() {
+			return nil, fmt.Errorf("too many failed attempts, share is locked")
+		}
+		return nil, fmt.Errorf("share has expired")
+	}
+
+	// Verify OTP
+	if magicToken.OTPHash == nil {
+		return nil, fmt.Errorf("token has no OTP configured")
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(*magicToken.OTPHash), []byte(otpInput)); err != nil {
+		// Wrong OTP — increment attempts
+		if incErr := s.repo.IncrementOTPAttempts(ctx, token); incErr != nil {
+			logger.Logger.Error("Failed to increment OTP attempts", "error", incErr)
+		}
+		remaining := magicToken.OTPMaxAttempts - magicToken.OTPAttempts - 1
+		logger.Logger.Warn("Document share OTP verification failed",
+			"email", magicToken.Email,
+			"attempts_remaining", remaining,
+			"ip", ip)
+		return nil, fmt.Errorf("invalid access code")
+	}
+
+	// OTP is correct — do NOT mark as used (multi-use token)
+	logger.Logger.Info("Document share OTP verified successfully",
+		"email", magicToken.Email,
+		"doc_id", magicToken.DocID,
+		"ip", ip)
+
+	return magicToken, nil
+}
+
+// RevokeDocumentShare revokes a document share by token ID
+func (s *MagicLinkService) RevokeDocumentShare(ctx context.Context, tokenID int64) error {
+	if err := s.repo.RevokeToken(ctx, tokenID); err != nil {
+		return fmt.Errorf("failed to revoke share: %w", err)
+	}
+
+	logger.Logger.Info("Document share revoked", "token_id", tokenID)
+	return nil
+}
+
+// ListDocumentShares returns all document_share tokens for a given document
+func (s *MagicLinkService) ListDocumentShares(ctx context.Context, docID string) ([]*models.MagicLinkToken, error) {
+	return s.repo.ListByDocAndPurpose(ctx, docID, "document_share")
+}
+
+// generateOTP generates a cryptographically secure 6-digit OTP
+func (s *MagicLinkService) generateOTP() (string, error) {
+	max := big.NewInt(1000000) // 0-999999
+	n, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%06d", n.Int64()), nil
 }

--- a/backend/internal/infrastructure/database/magic_link_repository.go
+++ b/backend/internal/infrastructure/database/magic_link_repository.go
@@ -24,8 +24,9 @@ func NewMagicLinkRepository(db *sql.DB) services.MagicLinkRepository {
 func (r *magicLinkRepo) CreateToken(ctx context.Context, token *models.MagicLinkToken) error {
 	query := `
 		INSERT INTO magic_link_tokens
-		(tenant_id, token, email, expires_at, redirect_to, created_by_ip, created_by_user_agent, purpose, doc_id)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		(tenant_id, token, email, expires_at, redirect_to, created_by_ip, created_by_user_agent, purpose, doc_id,
+		 otp_hash, otp_attempts, otp_max_attempts, shared_by)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 		RETURNING id, created_at
 	`
 
@@ -33,6 +34,12 @@ func (r *magicLinkRepo) CreateToken(ctx context.Context, token *models.MagicLink
 	purpose := token.Purpose
 	if purpose == "" {
 		purpose = "login"
+	}
+
+	// Set default max attempts
+	maxAttempts := token.OTPMaxAttempts
+	if maxAttempts == 0 {
+		maxAttempts = 5
 	}
 
 	return dbctx.GetQuerier(ctx, r.db).QueryRowContext(ctx, query,
@@ -45,6 +52,10 @@ func (r *magicLinkRepo) CreateToken(ctx context.Context, token *models.MagicLink
 		token.CreatedByUserAgent,
 		purpose,
 		token.DocID,
+		token.OTPHash,
+		token.OTPAttempts,
+		maxAttempts,
+		token.SharedBy,
 	).Scan(&token.ID, &token.CreatedAt)
 }
 
@@ -52,14 +63,14 @@ func (r *magicLinkRepo) GetByToken(ctx context.Context, token string) (*models.M
 	query := `
 		SELECT id, tenant_id, token, email, created_at, expires_at, used_at, used_by_ip,
 		       used_by_user_agent, redirect_to, created_by_ip, created_by_user_agent,
-		       purpose, doc_id
+		       purpose, doc_id, otp_hash, otp_attempts, otp_max_attempts, revoked_at, shared_by
 		FROM magic_link_tokens
 		WHERE token = $1
 	`
 
 	var t models.MagicLinkToken
-	var usedAt sql.NullTime
-	var usedByIP, usedByUserAgent, docID sql.NullString
+	var usedAt, revokedAt sql.NullTime
+	var usedByIP, usedByUserAgent, docID, otpHash, sharedBy sql.NullString
 	var tenantID sql.NullString
 
 	err := dbctx.GetQuerier(ctx, r.db).QueryRowContext(ctx, query, token).Scan(
@@ -77,6 +88,11 @@ func (r *magicLinkRepo) GetByToken(ctx context.Context, token string) (*models.M
 		&t.CreatedByUserAgent,
 		&t.Purpose,
 		&docID,
+		&otpHash,
+		&t.OTPAttempts,
+		&t.OTPMaxAttempts,
+		&revokedAt,
+		&sharedBy,
 	)
 
 	if err == sql.ErrNoRows {
@@ -101,6 +117,15 @@ func (r *magicLinkRepo) GetByToken(ctx context.Context, token string) (*models.M
 	}
 	if docID.Valid {
 		t.DocID = &docID.String
+	}
+	if otpHash.Valid {
+		t.OTPHash = &otpHash.String
+	}
+	if revokedAt.Valid {
+		t.RevokedAt = &revokedAt.Time
+	}
+	if sharedBy.Valid {
+		t.SharedBy = &sharedBy.String
 	}
 
 	return &t, nil
@@ -134,7 +159,8 @@ func (r *magicLinkRepo) MarkAsUsed(ctx context.Context, token string, ip string,
 func (r *magicLinkRepo) DeleteExpired(ctx context.Context) (int64, error) {
 	query := `
 		DELETE FROM magic_link_tokens
-		WHERE expires_at < now() OR (created_at < now() - INTERVAL '7 days' AND used_at IS NULL)
+		WHERE expires_at < now()
+		   OR (created_at < now() - INTERVAL '7 days' AND used_at IS NULL AND purpose != 'document_share')
 	`
 
 	result, err := dbctx.GetQuerier(ctx, r.db).ExecContext(ctx, query)
@@ -185,4 +211,115 @@ func (r *magicLinkRepo) CountRecentAttemptsByIP(ctx context.Context, ip string, 
 
 	err := dbctx.GetQuerier(ctx, r.db).QueryRowContext(ctx, query, ip, since).Scan(&count)
 	return count, err
+}
+
+func (r *magicLinkRepo) IncrementOTPAttempts(ctx context.Context, token string) error {
+	query := `
+		UPDATE magic_link_tokens
+		SET otp_attempts = otp_attempts + 1
+		WHERE token = $1
+	`
+
+	result, err := dbctx.GetQuerier(ctx, r.db).ExecContext(ctx, query, token)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return sql.ErrNoRows
+	}
+
+	return nil
+}
+
+func (r *magicLinkRepo) RevokeToken(ctx context.Context, tokenID int64) error {
+	query := `
+		UPDATE magic_link_tokens
+		SET revoked_at = now()
+		WHERE id = $1 AND revoked_at IS NULL
+	`
+
+	result, err := dbctx.GetQuerier(ctx, r.db).ExecContext(ctx, query, tokenID)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return sql.ErrNoRows
+	}
+
+	return nil
+}
+
+func (r *magicLinkRepo) ListByDocAndPurpose(ctx context.Context, docID string, purpose string) ([]*models.MagicLinkToken, error) {
+	query := `
+		SELECT id, tenant_id, email, created_at, expires_at, used_at,
+		       redirect_to, created_by_ip, purpose, doc_id,
+		       otp_attempts, otp_max_attempts, revoked_at, shared_by
+		FROM magic_link_tokens
+		WHERE doc_id = $1 AND purpose = $2
+		ORDER BY created_at DESC
+	`
+
+	rows, err := dbctx.GetQuerier(ctx, r.db).QueryContext(ctx, query, docID, purpose)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tokens []*models.MagicLinkToken
+	for rows.Next() {
+		var t models.MagicLinkToken
+		var usedAt, revokedAt sql.NullTime
+		var tenantID, docIDVal, sharedBy sql.NullString
+
+		err := rows.Scan(
+			&t.ID,
+			&tenantID,
+			&t.Email,
+			&t.CreatedAt,
+			&t.ExpiresAt,
+			&usedAt,
+			&t.RedirectTo,
+			&t.CreatedByIP,
+			&t.Purpose,
+			&docIDVal,
+			&t.OTPAttempts,
+			&t.OTPMaxAttempts,
+			&revokedAt,
+			&sharedBy,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if tenantID.Valid {
+			parsed, _ := uuid.Parse(tenantID.String)
+			t.TenantID = &parsed
+		}
+		if usedAt.Valid {
+			t.UsedAt = &usedAt.Time
+		}
+		if docIDVal.Valid {
+			t.DocID = &docIDVal.String
+		}
+		if revokedAt.Valid {
+			t.RevokedAt = &revokedAt.Time
+		}
+		if sharedBy.Valid {
+			t.SharedBy = &sharedBy.String
+		}
+
+		tokens = append(tokens, &t)
+	}
+
+	return tokens, rows.Err()
 }

--- a/backend/internal/presentation/api/admin/share_handler.go
+++ b/backend/internal/presentation/api/admin/share_handler.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/btouchard/ackify-ce/backend/internal/infrastructure/i18n"
+	"github.com/btouchard/ackify-ce/backend/internal/presentation/api/shared"
+	"github.com/btouchard/ackify-ce/backend/pkg/logger"
+	"github.com/btouchard/ackify-ce/backend/pkg/providers"
+	"github.com/go-chi/chi/v5"
+)
+
+// ShareHandler handles admin document sharing API requests
+type ShareHandler struct {
+	authProvider providers.AuthProvider
+}
+
+// NewShareHandler creates a new share handler
+func NewShareHandler(authProvider providers.AuthProvider) *ShareHandler {
+	return &ShareHandler{
+		authProvider: authProvider,
+	}
+}
+
+// HandleCreateDocumentShare handles POST /api/v1/admin/documents/{docId}/share
+func (h *ShareHandler) HandleCreateDocumentShare(w http.ResponseWriter, r *http.Request) {
+	docID := chi.URLParam(r, "docId")
+	if docID == "" {
+		shared.WriteError(w, http.StatusBadRequest, shared.ErrCodeValidation, "Document ID is required", nil)
+		return
+	}
+
+	var req struct {
+		Email        string `json:"email"`
+		ValidityDays int    `json:"validity_days"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		shared.WriteError(w, http.StatusBadRequest, shared.ErrCodeValidation, "Invalid request body", nil)
+		return
+	}
+
+	if req.Email == "" {
+		shared.WriteError(w, http.StatusBadRequest, shared.ErrCodeValidation, "Email is required", nil)
+		return
+	}
+
+	// Get the current admin user
+	currentUser, err := h.authProvider.GetCurrentUser(r)
+	if err != nil || currentUser == nil {
+		shared.WriteError(w, http.StatusUnauthorized, shared.ErrCodeUnauthorized, "Not authenticated", nil)
+		return
+	}
+
+	ctx := r.Context()
+	locale := i18n.GetLang(ctx)
+
+	linkURL, otp, err := h.authProvider.CreateDocumentShareLink(ctx, req.Email, docID, req.ValidityDays, currentUser.Email, locale)
+	if err != nil {
+		logger.Logger.Error("Failed to create document share", "error", err.Error())
+		shared.WriteError(w, http.StatusInternalServerError, shared.ErrCodeInternal, "Failed to create document share", nil)
+		return
+	}
+
+	shared.WriteJSON(w, http.StatusCreated, map[string]interface{}{
+		"otp":  otp,
+		"link": linkURL,
+	})
+}
+
+// HandleListDocumentShares handles GET /api/v1/admin/documents/{docId}/shares
+func (h *ShareHandler) HandleListDocumentShares(w http.ResponseWriter, r *http.Request) {
+	docID := chi.URLParam(r, "docId")
+	if docID == "" {
+		shared.WriteError(w, http.StatusBadRequest, shared.ErrCodeValidation, "Document ID is required", nil)
+		return
+	}
+
+	ctx := r.Context()
+	shares, err := h.authProvider.ListDocumentShares(ctx, docID)
+	if err != nil {
+		logger.Logger.Error("Failed to list document shares", "error", err.Error())
+		shared.WriteError(w, http.StatusInternalServerError, shared.ErrCodeInternal, "Failed to list shares", nil)
+		return
+	}
+
+	if shares == nil {
+		shares = []*providers.DocumentShareInfo{}
+	}
+
+	shared.WriteJSON(w, http.StatusOK, map[string]interface{}{
+		"shares": shares,
+	})
+}
+
+// HandleRevokeDocumentShare handles DELETE /api/v1/admin/documents/{docId}/share/{tokenId}
+func (h *ShareHandler) HandleRevokeDocumentShare(w http.ResponseWriter, r *http.Request) {
+	docID := chi.URLParam(r, "docId")
+	if docID == "" {
+		shared.WriteError(w, http.StatusBadRequest, shared.ErrCodeValidation, "Document ID is required", nil)
+		return
+	}
+
+	tokenIDStr := chi.URLParam(r, "tokenId")
+	tokenID, err := strconv.ParseInt(tokenIDStr, 10, 64)
+	if err != nil {
+		shared.WriteError(w, http.StatusBadRequest, shared.ErrCodeValidation, "Invalid token ID", nil)
+		return
+	}
+
+	ctx := r.Context()
+	if err := h.authProvider.RevokeDocumentShare(ctx, tokenID); err != nil {
+		logger.Logger.Error("Failed to revoke document share", "error", err.Error())
+		shared.WriteError(w, http.StatusInternalServerError, shared.ErrCodeInternal, "Failed to revoke share", nil)
+		return
+	}
+
+	shared.WriteJSON(w, http.StatusOK, map[string]string{
+		"message": "Share revoked successfully",
+	})
+}

--- a/backend/internal/presentation/api/auth/handler.go
+++ b/backend/internal/presentation/api/auth/handler.go
@@ -344,6 +344,237 @@ func (h *Handler) HandleVerifyReminderAuthLink(w http.ResponseWriter, r *http.Re
 	http.Redirect(w, r, redirectTo, http.StatusFound)
 }
 
+// === Document Share Handlers ===
+
+// HandleDocumentSharePage handles GET /api/v1/auth/document-share/verify
+// Validates the token exists and is valid, then serves an OTP input page
+func (h *Handler) HandleDocumentSharePage(w http.ResponseWriter, r *http.Request) {
+	token := r.URL.Query().Get("token")
+	if token == "" {
+		shared.WriteError(w, http.StatusBadRequest, shared.ErrCodeValidation, "Token is required", nil)
+		return
+	}
+
+	// Validate token exists and is a valid document_share (read-only, no OTP check)
+	ctx := r.Context()
+	if err := h.authProvider.ValidateDocumentShareToken(ctx, token); err != nil {
+		shared.WriteError(w, http.StatusUnauthorized, shared.ErrCodeUnauthorized, "Invalid or expired link", nil)
+		return
+	}
+
+	// Serve a self-contained HTML page with OTP input
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; script-src 'unsafe-inline'; img-src data:; connect-src 'self';")
+	w.WriteHeader(http.StatusOK)
+	page := strings.Replace(otpPageHTML, "{{TOKEN}}", token, 1)
+	w.Write([]byte(page))
+}
+
+const otpPageHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Access Code · Ackify</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:linear-gradient(135deg,#eef2f7 0%%,#e2e8f0 50%%,#dbeafe 100%);min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;color:#0f172a}
+
+.logo{display:flex;align-items:center;gap:10px;margin-bottom:32px}
+.logo svg{width:36px;height:36px}
+.logo span{font-size:1.5rem;font-weight:700;color:#0f172a}
+
+.card{background:#fff;border-radius:16px;box-shadow:0 1px 3px rgba(0,0,0,.06),0 8px 30px rgba(0,0,0,.04);padding:40px 36px;width:100%;max-width:420px;text-align:center}
+
+.lock-icon{width:48px;height:48px;margin:0 auto 20px;background:linear-gradient(135deg,#6366f1,#3b82f6);border-radius:12px;display:flex;align-items:center;justify-content:center}
+.lock-icon svg{width:24px;height:24px;color:#fff;fill:none;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
+
+h1{font-size:1.25rem;font-weight:700;color:#0f172a;margin-bottom:6px}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:28px;line-height:1.5}
+
+.otp-group{display:flex;gap:8px;justify-content:center;margin-bottom:20px}
+.otp-box{width:48px;height:56px;text-align:center;font-size:1.5rem;font-weight:600;font-family:'Inter',monospace;border:2px solid #e2e8f0;border-radius:10px;outline:none;transition:all .2s;color:#0f172a;background:#f8fafc}
+.otp-box:focus{border-color:#3b82f6;box-shadow:0 0 0 3px rgba(59,130,246,.15);background:#fff}
+.otp-box.filled{border-color:#94a3b8;background:#fff}
+
+.btn{width:100%;padding:13px 24px;background:#0f172a;color:#fff;border:none;border-radius:10px;font-size:.935rem;font-weight:600;font-family:'Inter',sans-serif;cursor:pointer;transition:all .2s;display:flex;align-items:center;justify-content:center;gap:8px}
+.btn:hover{background:#1e293b;transform:translateY(-1px);box-shadow:0 4px 12px rgba(15,23,42,.15)}
+.btn:active{transform:translateY(0)}
+.btn:disabled{background:#94a3b8;cursor:not-allowed;transform:none;box-shadow:none}
+
+.error-msg{color:#dc2626;font-size:.8rem;margin-top:14px;display:none;padding:8px 12px;background:#fef2f2;border-radius:8px;border:1px solid #fecaca}
+
+.spinner{display:none;width:18px;height:18px;border:2.5px solid rgba(255,255,255,.3);border-top-color:#fff;border-radius:50%%;animation:spin .5s linear infinite}
+@keyframes spin{to{transform:rotate(360deg)}}
+
+.footer{margin-top:24px;font-size:.75rem;color:#94a3b8}
+.footer a{color:#64748b;text-decoration:none}
+</style>
+</head>
+<body>
+
+<div class="logo">
+<svg viewBox="0 0 36 36" fill="none"><path d="M18 3L4 10v16l14 7 14-7V10L18 3z" fill="url(#g)"/><path d="M18 13l-7 4v7l7 4 7-4v-7l-7-4z" fill="#fff" fill-opacity=".9"/><defs><linearGradient id="g" x1="4" y1="3" x2="32" y2="33"><stop stop-color="#6366f1"/><stop offset="1" stop-color="#06b6d4"/></linearGradient></defs></svg>
+<span>Ackify</span>
+</div>
+
+<div class="card">
+<div class="lock-icon">
+<svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/><circle cx="12" cy="16" r="1" fill="currentColor"/></svg>
+</div>
+<h1>Secure Access</h1>
+<p class="subtitle">Enter the 6-digit code provided to you to access this document.</p>
+<form id="otp-form">
+<div class="otp-group">
+<input class="otp-box" type="text" maxlength="1" inputmode="numeric" pattern="[0-9]" autofocus>
+<input class="otp-box" type="text" maxlength="1" inputmode="numeric" pattern="[0-9]">
+<input class="otp-box" type="text" maxlength="1" inputmode="numeric" pattern="[0-9]">
+<input class="otp-box" type="text" maxlength="1" inputmode="numeric" pattern="[0-9]">
+<input class="otp-box" type="text" maxlength="1" inputmode="numeric" pattern="[0-9]">
+<input class="otp-box" type="text" maxlength="1" inputmode="numeric" pattern="[0-9]">
+</div>
+<button class="btn" type="submit" id="submit-btn">
+<span id="btn-text">Verify Access Code</span>
+<div class="spinner" id="spinner"></div>
+</button>
+<div class="error-msg" id="error"></div>
+</form>
+</div>
+<div class="footer">Secured by Ackify · Your authentication is encrypted</div>
+
+<script>
+const token = "{{TOKEN}}";
+const boxes = document.querySelectorAll(".otp-box");
+const form = document.getElementById("otp-form");
+const errorEl = document.getElementById("error");
+const spinner = document.getElementById("spinner");
+const btnText = document.getElementById("btn-text");
+const btn = document.getElementById("submit-btn");
+
+boxes.forEach((box, i) => {
+  box.addEventListener("input", function(e) {
+    this.value = this.value.replace(/\D/g, "");
+    if (this.value && i < boxes.length - 1) boxes[i + 1].focus();
+    this.classList.toggle("filled", !!this.value);
+    errorEl.style.display = "none";
+  });
+  box.addEventListener("keydown", function(e) {
+    if (e.key === "Backspace" && !this.value && i > 0) {
+      boxes[i - 1].focus();
+      boxes[i - 1].value = "";
+      boxes[i - 1].classList.remove("filled");
+    }
+  });
+  box.addEventListener("paste", function(e) {
+    e.preventDefault();
+    const data = (e.clipboardData || window.clipboardData).getData("text").replace(/\D/g, "").slice(0, 6);
+    data.split("").forEach((ch, j) => {
+      if (boxes[j]) { boxes[j].value = ch; boxes[j].classList.add("filled"); }
+    });
+    if (data.length > 0) boxes[Math.min(data.length, 5)].focus();
+  });
+});
+
+function getOTP() { return Array.from(boxes).map(b => b.value).join(""); }
+
+form.addEventListener("submit", async function(e) {
+  e.preventDefault();
+  const otp = getOTP();
+  if (otp.length !== 6) { boxes[0].focus(); return; }
+  btn.disabled = true;
+  btnText.textContent = "Verifying...";
+  spinner.style.display = "block";
+  errorEl.style.display = "none";
+  try {
+    const resp = await fetch("/api/v1/auth/document-share/verify-otp", {
+      method: "POST", credentials: "include",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({token: token, otp: otp})
+    });
+    const data = await resp.json();
+    if (resp.ok && data.data && data.data.redirect_to) {
+      btnText.textContent = "Redirecting...";
+      window.location.href = data.data.redirect_to;
+    } else {
+      errorEl.textContent = "Invalid code. Please check and try again.";
+      errorEl.style.display = "block";
+      btn.disabled = false;
+      btnText.textContent = "Verify Access Code";
+      spinner.style.display = "none";
+      boxes.forEach(b => { b.value = ""; b.classList.remove("filled"); });
+      boxes[0].focus();
+    }
+  } catch(err) {
+    errorEl.textContent = "Something went wrong. Please try again.";
+    errorEl.style.display = "block";
+    btn.disabled = false;
+    btnText.textContent = "Verify Access Code";
+    spinner.style.display = "none";
+  }
+});
+</script>
+</body>
+</html>`
+
+// HandleVerifyDocumentShareOTP handles POST /api/v1/auth/document-share/verify-otp
+func (h *Handler) HandleVerifyDocumentShareOTP(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Token string `json:"token"`
+		OTP   string `json:"otp"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		shared.WriteError(w, http.StatusBadRequest, shared.ErrCodeValidation, "Invalid request body", nil)
+		return
+	}
+
+	if req.Token == "" {
+		shared.WriteError(w, http.StatusBadRequest, shared.ErrCodeValidation, "Token is required", nil)
+		return
+	}
+
+	if req.OTP == "" {
+		shared.WriteError(w, http.StatusBadRequest, shared.ErrCodeValidation, "Access code is required", nil)
+		return
+	}
+
+	ip := extractIP(r.RemoteAddr)
+	userAgent := r.UserAgent()
+	ctx := r.Context()
+
+	result, err := h.authProvider.VerifyDocumentShareOTP(ctx, req.Token, req.OTP, ip, userAgent)
+	if err != nil {
+		logger.Logger.Warn("Document share OTP verification failed", "error", err.Error(), "ip", ip)
+		// Return a generic error message to avoid leaking internal state
+		shared.WriteError(w, http.StatusUnauthorized, shared.ErrCodeUnauthorized, "Invalid or expired link or access code", nil)
+		return
+	}
+
+	// Create user session from document share result
+	user := &types.User{
+		Sub:   "docshare:" + result.Email,
+		Email: result.Email,
+		Name:  result.Email,
+	}
+
+	if err := h.authProvider.SetCurrentUser(w, r, user); err != nil {
+		logger.Logger.Error("Failed to set user session", "error", err.Error())
+		shared.WriteError(w, http.StatusInternalServerError, shared.ErrCodeInternal, "Failed to create session", nil)
+		return
+	}
+
+	redirectTo := result.RedirectTo
+	if redirectTo == "" {
+		redirectTo = "/"
+	}
+
+	shared.WriteJSON(w, http.StatusOK, map[string]string{
+		"redirect_to": redirectTo,
+	})
+}
+
 func extractIP(remoteAddr string) string {
 	host, _, err := net.SplitHostPort(remoteAddr)
 	if err != nil {

--- a/backend/internal/presentation/api/auth/handler_test.go
+++ b/backend/internal/presentation/api/auth/handler_test.go
@@ -182,6 +182,30 @@ func (m *mockAuthProvider) CreateReminderAuthToken(_ context.Context, _, _ strin
 	return "test-token", nil
 }
 
+// Document Share methods
+func (m *mockAuthProvider) CreateDocumentShareLink(_ context.Context, _, _ string, _ int, _, _ string) (string, string, error) {
+	return "https://example.com/api/v1/auth/document-share/verify?token=test-token", "123456", nil
+}
+
+func (m *mockAuthProvider) ValidateDocumentShareToken(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *mockAuthProvider) VerifyDocumentShareOTP(_ context.Context, _, _, _, _ string) (*providers.MagicLinkResult, error) {
+	return &providers.MagicLinkResult{
+		Email:      "test@example.com",
+		RedirectTo: "/?doc=test-doc",
+	}, nil
+}
+
+func (m *mockAuthProvider) RevokeDocumentShare(_ context.Context, _ int64) error {
+	return nil
+}
+
+func (m *mockAuthProvider) ListDocumentShares(_ context.Context, _ string) ([]*providers.DocumentShareInfo, error) {
+	return []*providers.DocumentShareInfo{}, nil
+}
+
 // Helper for tests
 func (m *mockAuthProvider) setOIDCEnabled(enabled bool) {
 	m.mu.Lock()

--- a/backend/internal/presentation/api/router.go
+++ b/backend/internal/presentation/api/router.go
@@ -34,6 +34,8 @@ type magicLinkService interface {
 	RequestMagicLink(ctx context.Context, email, redirectTo, ip, userAgent, locale string) error
 	VerifyMagicLink(ctx context.Context, token, ip, userAgent string) (*models.MagicLinkToken, error)
 	VerifyReminderAuthToken(ctx context.Context, token, ip, userAgent string) (*models.MagicLinkToken, error)
+	CreateDocumentShareLink(ctx context.Context, email, docID string, validityDays int, sharedBy, locale string) (string, string, error)
+	VerifyDocumentShareOTP(ctx context.Context, token, otp, ip, userAgent string) (*models.MagicLinkToken, error)
 }
 
 // signatureService defines signature operations
@@ -234,6 +236,10 @@ func NewRouter(cfg RouterConfig) *chi.Mux {
 				r.Get("/magic-link/verify", authHandler.HandleVerifyMagicLink)
 				r.Get("/reminder-link/verify", authHandler.HandleVerifyReminderAuthLink)
 
+				// Document Share endpoints (OTP-protected magic links)
+				r.Get("/document-share/verify", authHandler.HandleDocumentSharePage)
+				r.Post("/document-share/verify-otp", authHandler.HandleVerifyDocumentShareOTP)
+
 				// Logout endpoint (always available)
 				r.Get("/logout", authHandler.HandleLogout)
 			})
@@ -325,6 +331,7 @@ func NewRouter(cfg RouterConfig) *chi.Mux {
 		// Initialize admin handler
 		adminHandler := apiAdmin.NewHandler(cfg.AdminService, cfg.ReminderService, cfg.SignatureService, cfg.BaseURL, importMaxSigners)
 		webhooksHandler := apiAdmin.NewWebhooksHandler(cfg.WebhookService)
+		shareHandler := apiAdmin.NewShareHandler(cfg.AuthProvider)
 
 		r.Route("/admin", func(r chi.Router) {
 			// Document management
@@ -351,6 +358,11 @@ func NewRouter(cfg RouterConfig) *chi.Mux {
 				// Reminder management
 				r.Post("/{docId}/reminders", adminHandler.HandleSendReminders)
 				r.Get("/{docId}/reminders", adminHandler.HandleGetReminderHistory)
+
+				// Document sharing (magic link + OTP)
+				r.Post("/{docId}/share", shareHandler.HandleCreateDocumentShare)
+				r.Get("/{docId}/shares", shareHandler.HandleListDocumentShares)
+				r.Delete("/{docId}/share/{tokenId}", shareHandler.HandleRevokeDocumentShare)
 			})
 
 			// Webhooks management

--- a/backend/internal/presentation/api/shared/middleware.go
+++ b/backend/internal/presentation/api/shared/middleware.go
@@ -244,7 +244,7 @@ func SecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Check if this is a content endpoint that needs to be embeddable
 		path := r.URL.Path
-		isContentEndpoint := strings.Contains(path, "/content") || strings.Contains(path, "/proxy")
+		isContentEndpoint := strings.Contains(path, "/content") || strings.Contains(path, "/proxy") || strings.Contains(path, "/document-share/verify")
 
 		// Security headers
 		w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/backend/internal/presentation/api/shared/middleware_test.go
+++ b/backend/internal/presentation/api/shared/middleware_test.go
@@ -111,6 +111,21 @@ func (m *mockAuthProvider) VerifyReminderAuthToken(context.Context, string, stri
 func (m *mockAuthProvider) CreateReminderAuthToken(context.Context, string, string) (string, error) {
 	return "", nil
 }
+func (m *mockAuthProvider) CreateDocumentShareLink(ctx context.Context, email, docID string, validityDays int, sharedBy, locale string) (string, string, error) {
+	return "", "", nil
+}
+func (m *mockAuthProvider) ValidateDocumentShareToken(ctx context.Context, token string) error {
+	return nil
+}
+func (m *mockAuthProvider) VerifyDocumentShareOTP(ctx context.Context, token, otp, ip, userAgent string) (*providers.MagicLinkResult, error) {
+	return nil, nil
+}
+func (m *mockAuthProvider) ListDocumentShares(ctx context.Context, docID string) ([]*providers.DocumentShareInfo, error) {
+	return nil, nil
+}
+func (m *mockAuthProvider) RevokeDocumentShare(ctx context.Context, tokenID int64) error {
+	return nil
+}
 
 // mockAuthorizer is a test implementation of providers.Authorizer
 type mockAuthorizer struct {

--- a/backend/locales/de.json
+++ b/backend/locales/de.json
@@ -14,7 +14,6 @@
   "email.reminder.contact": "Bei Fragen wenden Sie sich bitte an Ihren Administrator.",
   "email.reminder.regards": "Mit freundlichen Grüßen,",
   "email.reminder.team": "Das {{.Organisation}}-Team",
-
   "email.magic_link.subject": "Ihr Anmeldelink",
   "email.magic_link.title": "🔐 Ihr Anmeldelink",
   "email.magic_link.greeting": "Hallo,",
@@ -25,5 +24,18 @@
   "email.magic_link.warning_text": "Dieser Link läuft in {{.ExpiresIn}} Minuten ab und kann nur einmal verwendet werden.",
   "email.magic_link.not_requested": "Wenn Sie diesen Link nicht angefordert haben, können Sie diese E-Mail sicher ignorieren.",
   "email.magic_link.button_not_working": "Wenn die Schaltfläche nicht funktioniert, kopieren Sie diesen Link in Ihren Browser:",
-  "email.magic_link.footer": "Diese E-Mail wurde von {{.Organisation}} gesendet – {{.BaseURL}}"
+  "email.magic_link.footer": "Diese E-Mail wurde von {{.Organisation}} gesendet – {{.BaseURL}}",
+  "email.document_share.subject": "Ein Dokument wurde mit Ihnen geteilt",
+  "email.document_share.title": "📄 Ein Dokument wurde mit Ihnen geteilt",
+  "email.document_share.greeting": "Hallo,",
+  "email.document_share.intro": "Jemand von {{.Organisation}} hat ein Dokument mit Ihnen geteilt ({{.Email}}).",
+  "email.document_share.instructions": "Klicken Sie auf die Schaltfläche unten, um auf das Dokument zuzugreifen:",
+  "email.document_share.cta_button": "📄 Dokument ansehen",
+  "email.document_share.otp_notice_title": "Zugangscode erforderlich:",
+  "email.document_share.otp_notice_text": "Sie benötigen einen Zugangscode, um dieses Dokument anzuzeigen.",
+  "email.document_share.warning_title": "Achtung:",
+  "email.document_share.warning_text": "Dieser Link läuft in {{.ValidityDays}} Tagen ab.",
+  "email.document_share.not_requested": "Wenn Sie dieses Dokument nicht erwartet haben, können Sie diese E-Mail sicher ignorieren.",
+  "email.document_share.button_not_working": "Wenn die Schaltfläche nicht funktioniert, kopieren Sie diesen Link in Ihren Browser:",
+  "email.document_share.footer": "Diese E-Mail wurde von {{.Organisation}} gesendet – {{.BaseURL}}"
 }

--- a/backend/locales/en.json
+++ b/backend/locales/en.json
@@ -25,5 +25,19 @@
   "email.magic_link.warning_text": "This link expires in {{.ExpiresIn}} minutes and can only be used once.",
   "email.magic_link.not_requested": "If you did not request this link, you can safely ignore this email.",
   "email.magic_link.button_not_working": "If the button doesn't work, copy and paste this link into your browser:",
-  "email.magic_link.footer": "This email was sent by {{.Organisation}} – {{.BaseURL}}"
+  "email.magic_link.footer": "This email was sent by {{.Organisation}} – {{.BaseURL}}",
+
+  "email.document_share.subject": "A document has been shared with you",
+  "email.document_share.title": "📄 A document has been shared with you",
+  "email.document_share.greeting": "Hello,",
+  "email.document_share.intro": "Someone from {{.Organisation}} has shared a document with you ({{.Email}}).",
+  "email.document_share.instructions": "Click the button below to access the document:",
+  "email.document_share.cta_button": "📄 View Document",
+  "email.document_share.otp_notice_title": "Access code required:",
+  "email.document_share.otp_notice_text": "You will need an access code to view this document. The person who shared it with you will provide it separately.",
+  "email.document_share.warning_title": "Attention:",
+  "email.document_share.warning_text": "This link expires in {{.ValidityDays}} days.",
+  "email.document_share.not_requested": "If you were not expecting this document, you can safely ignore this email.",
+  "email.document_share.button_not_working": "If the button doesn't work, copy and paste this link into your browser:",
+  "email.document_share.footer": "This email was sent by {{.Organisation}} – {{.BaseURL}}"
 }

--- a/backend/locales/es.json
+++ b/backend/locales/es.json
@@ -14,7 +14,6 @@
   "email.reminder.contact": "Si tiene alguna pregunta, póngase en contacto con su administrador.",
   "email.reminder.regards": "Saludos cordiales,",
   "email.reminder.team": "El equipo de {{.Organisation}}",
-
   "email.magic_link.subject": "Su enlace de inicio de sesión",
   "email.magic_link.title": "🔐 Su enlace de inicio de sesión",
   "email.magic_link.greeting": "Hola,",
@@ -25,5 +24,18 @@
   "email.magic_link.warning_text": "Este enlace caduca en {{.ExpiresIn}} minutos y solo se puede usar una vez.",
   "email.magic_link.not_requested": "Si no solicitó este enlace, puede ignorar este correo electrónico de forma segura.",
   "email.magic_link.button_not_working": "Si el botón no funciona, copie y pegue este enlace en su navegador:",
-  "email.magic_link.footer": "Este correo electrónico fue enviado por {{.Organisation}} – {{.BaseURL}}"
+  "email.magic_link.footer": "Este correo electrónico fue enviado por {{.Organisation}} – {{.BaseURL}}",
+  "email.document_share.subject": "Se ha compartido un documento contigo",
+  "email.document_share.title": "📄 Se ha compartido un documento contigo",
+  "email.document_share.greeting": "Hola,",
+  "email.document_share.intro": "Alguien de {{.Organisation}} ha compartido un documento contigo ({{.Email}}).",
+  "email.document_share.instructions": "Haz clic en el botón de abajo para acceder al documento:",
+  "email.document_share.cta_button": "📄 Ver Documento",
+  "email.document_share.otp_notice_title": "Código de acceso requerido:",
+  "email.document_share.otp_notice_text": "Necesitarás un código de acceso para ver este documento. La persona que lo compartió te lo proporcionará por separado.",
+  "email.document_share.warning_title": "Atención:",
+  "email.document_share.warning_text": "Este enlace caduca en {{.ValidityDays}} días.",
+  "email.document_share.not_requested": "Si no esperabas este documento, puedes ignorar este correo de forma segura.",
+  "email.document_share.button_not_working": "Si el botón no funciona, copia y pega este enlace en tu navegador:",
+  "email.document_share.footer": "Este correo electrónico fue enviado por {{.Organisation}} – {{.BaseURL}}"
 }

--- a/backend/locales/fr.json
+++ b/backend/locales/fr.json
@@ -14,7 +14,6 @@
   "email.reminder.contact": "Si vous avez des questions, veuillez contacter votre administrateur.",
   "email.reminder.regards": "Cordialement,",
   "email.reminder.team": "L'équipe {{.Organisation}}",
-
   "email.magic_link.subject": "Votre lien de connexion",
   "email.magic_link.title": "🔐 Votre lien de connexion",
   "email.magic_link.greeting": "Bonjour,",
@@ -25,5 +24,18 @@
   "email.magic_link.warning_text": "Ce lien expire dans {{.ExpiresIn}} minutes et ne peut être utilisé qu'une seule fois.",
   "email.magic_link.not_requested": "Si vous n'avez pas demandé ce lien, vous pouvez ignorer cet email en toute sécurité.",
   "email.magic_link.button_not_working": "Si le bouton ne fonctionne pas, copiez et collez ce lien dans votre navigateur :",
-  "email.magic_link.footer": "Cet email a été envoyé par {{.Organisation}} – {{.BaseURL}}"
+  "email.magic_link.footer": "Cet email a été envoyé par {{.Organisation}} – {{.BaseURL}}",
+  "email.document_share.subject": "Un document a été partagé avec vous",
+  "email.document_share.title": "📄 Un document a été partagé avec vous",
+  "email.document_share.greeting": "Bonjour,",
+  "email.document_share.intro": "Quelqu'un de {{.Organisation}} a partagé un document avec vous ({{.Email}}).",
+  "email.document_share.instructions": "Cliquez sur le bouton ci-dessous pour accéder au document :",
+  "email.document_share.cta_button": "📄 Voir le document",
+  "email.document_share.otp_notice_title": "Code d'accès requis :",
+  "email.document_share.otp_notice_text": "Vous aurez besoin d'un code d'accès pour consulter ce document. La personne qui l'a partagé vous le communiquera séparément.",
+  "email.document_share.warning_title": "Attention :",
+  "email.document_share.warning_text": "Ce lien expire dans {{.ValidityDays}} jours.",
+  "email.document_share.not_requested": "Si vous n'attendiez pas ce document, vous pouvez ignorer cet email en toute sécurité.",
+  "email.document_share.button_not_working": "Si le bouton ne fonctionne pas, copiez et collez ce lien dans votre navigateur :",
+  "email.document_share.footer": "Cet email a été envoyé par {{.Organisation}} – {{.BaseURL}}"
 }

--- a/backend/locales/it.json
+++ b/backend/locales/it.json
@@ -14,7 +14,6 @@
   "email.reminder.contact": "Se hai domande, contatta il tuo amministratore.",
   "email.reminder.regards": "Cordiali saluti,",
   "email.reminder.team": "Il team {{.Organisation}}",
-
   "email.magic_link.subject": "Il tuo link di accesso",
   "email.magic_link.title": "🔐 Il tuo link di accesso",
   "email.magic_link.greeting": "Ciao,",
@@ -25,5 +24,18 @@
   "email.magic_link.warning_text": "Questo link scade tra {{.ExpiresIn}} minuti e può essere utilizzato solo una volta.",
   "email.magic_link.not_requested": "Se non hai richiesto questo link, puoi ignorare questa email in tutta sicurezza.",
   "email.magic_link.button_not_working": "Se il pulsante non funziona, copia e incolla questo link nel tuo browser:",
-  "email.magic_link.footer": "Questa email è stata inviata da {{.Organisation}} – {{.BaseURL}}"
+  "email.magic_link.footer": "Questa email è stata inviata da {{.Organisation}} – {{.BaseURL}}",
+  "email.document_share.subject": "Un documento è stato condiviso con te",
+  "email.document_share.title": "📄 Un documento è stato condiviso con te",
+  "email.document_share.greeting": "Ciao,",
+  "email.document_share.intro": "Qualcuno di {{.Organisation}} ha condiviso un documento con te ({{.Email}}).",
+  "email.document_share.instructions": "Fai clic sul pulsante qui sotto per accedere al documento:",
+  "email.document_share.cta_button": "📄 Visualizza Documento",
+  "email.document_share.otp_notice_title": "Codice di accesso richiesto:",
+  "email.document_share.otp_notice_text": "Avrai bisogno di un codice di accesso per visualizzare questo documento. La persona che l'ha condiviso te lo fornirà separatamente.",
+  "email.document_share.warning_title": "Attenzione:",
+  "email.document_share.warning_text": "Questo link scade tra {{.ValidityDays}} giorni.",
+  "email.document_share.not_requested": "Se non stavi aspettando questo documento, puoi ignorare questa email in tutta sicurezza.",
+  "email.document_share.button_not_working": "Se il pulsante non funziona, copia e incolla questo link nel tuo browser:",
+  "email.document_share.footer": "Questa email è stata inviata da {{.Organisation}} – {{.BaseURL}}"
 }

--- a/backend/migrations/0020_add_document_share_otp.down.sql
+++ b/backend/migrations/0020_add_document_share_otp.down.sql
@@ -1,0 +1,13 @@
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+-- Rollback migration 0014: Remove OTP document share columns
+
+DROP INDEX IF EXISTS idx_magic_link_tokens_revoked;
+DROP INDEX IF EXISTS idx_magic_link_tokens_doc_purpose;
+
+ALTER TABLE magic_link_tokens
+  DROP COLUMN IF EXISTS shared_by,
+  DROP COLUMN IF EXISTS revoked_at,
+  DROP COLUMN IF EXISTS otp_max_attempts,
+  DROP COLUMN IF EXISTS otp_attempts,
+  DROP COLUMN IF EXISTS otp_hash;

--- a/backend/migrations/0020_add_document_share_otp.up.sql
+++ b/backend/migrations/0020_add_document_share_otp.up.sql
@@ -1,0 +1,25 @@
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+-- Migration 0014: Add OTP support for document sharing via magic links
+-- Adds columns for OTP hash, attempt tracking, revocation, and share origin
+
+ALTER TABLE magic_link_tokens
+  ADD COLUMN otp_hash TEXT,
+  ADD COLUMN otp_attempts INT NOT NULL DEFAULT 0,
+  ADD COLUMN otp_max_attempts INT NOT NULL DEFAULT 5,
+  ADD COLUMN revoked_at TIMESTAMPTZ,
+  ADD COLUMN shared_by TEXT;
+
+-- Index for listing shares per document
+CREATE INDEX idx_magic_link_tokens_doc_purpose ON magic_link_tokens(doc_id, purpose)
+  WHERE doc_id IS NOT NULL;
+
+-- Index for filtering out revoked tokens
+CREATE INDEX idx_magic_link_tokens_revoked ON magic_link_tokens(revoked_at)
+  WHERE revoked_at IS NOT NULL;
+
+COMMENT ON COLUMN magic_link_tokens.otp_hash IS 'Bcrypt hash of the 6-digit OTP (NULL for non-OTP tokens)';
+COMMENT ON COLUMN magic_link_tokens.otp_attempts IS 'Number of failed OTP verification attempts';
+COMMENT ON COLUMN magic_link_tokens.otp_max_attempts IS 'Maximum allowed OTP attempts before lockout (default: 5)';
+COMMENT ON COLUMN magic_link_tokens.revoked_at IS 'Timestamp when the share was revoked (NULL = active)';
+COMMENT ON COLUMN magic_link_tokens.shared_by IS 'Email of the admin who created the document share';

--- a/backend/pkg/models/magic_link.go
+++ b/backend/pkg/models/magic_link.go
@@ -21,19 +21,38 @@ type MagicLinkToken struct {
 	RedirectTo         string     `json:"redirect_to" db:"redirect_to"` // URL destination après auth (ex: /?doc=xxx)
 	CreatedByIP        string     `json:"created_by_ip" db:"created_by_ip"`
 	CreatedByUserAgent string     `json:"created_by_user_agent" db:"created_by_user_agent"`
-	Purpose            string     `json:"purpose" db:"purpose"`         // 'login' or 'reminder_auth'
-	DocID              *string    `json:"doc_id,omitempty" db:"doc_id"` // Document ID for reminder_auth (NULL for login)
+	Purpose            string     `json:"purpose" db:"purpose"`         // 'login', 'reminder_auth', or 'document_share'
+	DocID              *string    `json:"doc_id,omitempty" db:"doc_id"` // Document ID for reminder_auth/document_share (NULL for login)
+
+	// OTP fields (used for document_share purpose)
+	OTPHash        *string    `json:"-" db:"otp_hash"`                        // Bcrypt hash of the 6-digit OTP (never exposed in JSON)
+	OTPAttempts    int        `json:"otp_attempts" db:"otp_attempts"`         // Failed OTP verification attempts
+	OTPMaxAttempts int        `json:"otp_max_attempts" db:"otp_max_attempts"` // Max allowed failed attempts (default: 5)
+	RevokedAt      *time.Time `json:"revoked_at,omitempty" db:"revoked_at"`   // When the share was revoked (NULL = active)
+	SharedBy       *string    `json:"shared_by,omitempty" db:"shared_by"`     // Email of the admin who created the share
 }
 
-// IsValid vérifie si le token est valide (non expiré, non utilisé)
+// IsValid vérifie si le token est valide (non expiré, non utilisé, non révoqué, non verrouillé OTP)
 func (t *MagicLinkToken) IsValid() bool {
-	if t.UsedAt != nil {
-		return false // Déjà utilisé
+	if t.RevokedAt != nil {
+		return false // Révoqué
+	}
+	// For document_share tokens, we don't check UsedAt (they are multi-use)
+	if t.Purpose != "document_share" && t.UsedAt != nil {
+		return false // Déjà utilisé (single-use tokens only)
 	}
 	if time.Now().After(t.ExpiresAt) {
 		return false // Expiré
 	}
+	if t.IsOTPLocked() {
+		return false // Trop de tentatives OTP
+	}
 	return true
+}
+
+// IsOTPLocked returns true if the OTP attempt limit has been reached
+func (t *MagicLinkToken) IsOTPLocked() bool {
+	return t.OTPMaxAttempts > 0 && t.OTPAttempts >= t.OTPMaxAttempts
 }
 
 // MagicLinkAuthAttempt représente une tentative d'authentification

--- a/backend/pkg/providers/interfaces.go
+++ b/backend/pkg/providers/interfaces.go
@@ -6,6 +6,7 @@ package providers
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/btouchard/ackify-ce/backend/pkg/types"
 	"github.com/google/uuid"
@@ -74,6 +75,25 @@ type AuthProvider interface {
 
 	// CreateReminderAuthToken creates an auth token for reminder emails.
 	CreateReminderAuthToken(ctx context.Context, email, docID string) (string, error)
+
+	// === Document Share with OTP ===
+
+	// CreateDocumentShareLink creates a magic link protected by OTP for sharing a document.
+	// Returns the link URL and the cleartext OTP (shown once to the admin).
+	CreateDocumentShareLink(ctx context.Context, email, docID string, validityDays int, sharedBy, locale string) (linkURL string, otp string, err error)
+
+	// ValidateDocumentShareToken checks if a token is a valid, active document_share token.
+	// This is a read-only check that does NOT verify OTP or modify attempt counters.
+	ValidateDocumentShareToken(ctx context.Context, token string) error
+
+	// VerifyDocumentShareOTP verifies the OTP for a document share token.
+	VerifyDocumentShareOTP(ctx context.Context, token, otp, ip, userAgent string) (*MagicLinkResult, error)
+
+	// RevokeDocumentShare revokes a document share by token ID.
+	RevokeDocumentShare(ctx context.Context, tokenID int64) error
+
+	// ListDocumentShares returns all document shares for a given document.
+	ListDocumentShares(ctx context.Context, docID string) ([]*DocumentShareInfo, error)
 }
 
 // MagicLinkResult represents the result of verifying a magic link.
@@ -81,6 +101,19 @@ type MagicLinkResult struct {
 	Email      string
 	RedirectTo string
 	DocID      *string // Non-nil for reminder auth tokens
+}
+
+// DocumentShareInfo represents info about a document share for the admin listing.
+type DocumentShareInfo struct {
+	ID             int64      `json:"id"`
+	Email          string     `json:"email"`
+	CreatedAt      time.Time  `json:"created_at"`
+	ExpiresAt      time.Time  `json:"expires_at"`
+	OTPAttempts    int        `json:"otp_attempts"`
+	OTPMaxAttempts int        `json:"otp_max_attempts"`
+	RevokedAt      *time.Time `json:"revoked_at,omitempty"`
+	SharedBy       *string    `json:"shared_by,omitempty"`
+	IsActive       bool       `json:"is_active"`
 }
 
 // Authorizer defines the interface for authorization decisions.

--- a/backend/pkg/web/auth/dynamic_provider.go
+++ b/backend/pkg/web/auth/dynamic_provider.go
@@ -31,6 +31,11 @@ type magicLinkService interface {
 	VerifyMagicLink(ctx context.Context, token, ip, userAgent string) (*models.MagicLinkToken, error)
 	VerifyReminderAuthToken(ctx context.Context, token, ip, userAgent string) (*models.MagicLinkToken, error)
 	CreateReminderAuthToken(ctx context.Context, email, docID string) (string, error)
+	CreateDocumentShareLink(ctx context.Context, email, docID string, validityDays int, sharedBy, locale string) (string, string, error)
+	ValidateDocumentShareToken(ctx context.Context, token string) error
+	VerifyDocumentShareOTP(ctx context.Context, token, otp, ip, userAgent string) (*models.MagicLinkToken, error)
+	RevokeDocumentShare(ctx context.Context, tokenID int64) error
+	ListDocumentShares(ctx context.Context, docID string) ([]*models.MagicLinkToken, error)
 }
 
 // ProviderConfig holds a configuration for creating a Provider.
@@ -328,6 +333,74 @@ func (p *Provider) CreateReminderAuthToken(ctx context.Context, email, docID str
 		return "", fmt.Errorf("MagicLink service not configured")
 	}
 	return p.magicLinkService.CreateReminderAuthToken(ctx, email, docID)
+}
+
+// === Document Share with OTP ===
+
+func (p *Provider) CreateDocumentShareLink(ctx context.Context, email, docID string, validityDays int, sharedBy, locale string) (string, string, error) {
+	if p.magicLinkService == nil {
+		return "", "", fmt.Errorf("MagicLink service not configured")
+	}
+	return p.magicLinkService.CreateDocumentShareLink(ctx, email, docID, validityDays, sharedBy, locale)
+}
+
+func (p *Provider) ValidateDocumentShareToken(ctx context.Context, token string) error {
+	if p.magicLinkService == nil {
+		return fmt.Errorf("MagicLink service not configured")
+	}
+	return p.magicLinkService.ValidateDocumentShareToken(ctx, token)
+}
+
+func (p *Provider) VerifyDocumentShareOTP(ctx context.Context, token, otp, ip, userAgent string) (*providers.MagicLinkResult, error) {
+	if p.magicLinkService == nil {
+		return nil, fmt.Errorf("MagicLink service not configured")
+	}
+
+	result, err := p.magicLinkService.VerifyDocumentShareOTP(ctx, token, otp, ip, userAgent)
+	if err != nil {
+		return nil, err
+	}
+
+	return &providers.MagicLinkResult{
+		Email:      result.Email,
+		RedirectTo: result.RedirectTo,
+		DocID:      result.DocID,
+	}, nil
+}
+
+func (p *Provider) RevokeDocumentShare(ctx context.Context, tokenID int64) error {
+	if p.magicLinkService == nil {
+		return fmt.Errorf("MagicLink service not configured")
+	}
+	return p.magicLinkService.RevokeDocumentShare(ctx, tokenID)
+}
+
+func (p *Provider) ListDocumentShares(ctx context.Context, docID string) ([]*providers.DocumentShareInfo, error) {
+	if p.magicLinkService == nil {
+		return nil, fmt.Errorf("MagicLink service not configured")
+	}
+
+	tokens, err := p.magicLinkService.ListDocumentShares(ctx, docID)
+	if err != nil {
+		return nil, err
+	}
+
+	var shares []*providers.DocumentShareInfo
+	for _, t := range tokens {
+		shares = append(shares, &providers.DocumentShareInfo{
+			ID:             t.ID,
+			Email:          t.Email,
+			CreatedAt:      t.CreatedAt,
+			ExpiresAt:      t.ExpiresAt,
+			OTPAttempts:    t.OTPAttempts,
+			OTPMaxAttempts: t.OTPMaxAttempts,
+			RevokedAt:      t.RevokedAt,
+			SharedBy:       t.SharedBy,
+			IsActive:       t.IsValid(),
+		})
+	}
+
+	return shares, nil
 }
 
 // === Internal helpers ===

--- a/backend/templates/document_share.html.tmpl
+++ b/backend/templates/document_share.html.tmpl
@@ -1,0 +1,49 @@
+{{define "content"}}
+<h2>{{T "email.document_share.title"}}</h2>
+
+<p>{{T "email.document_share.greeting"}}</p>
+
+<p>{{T "email.document_share.intro" (dict "Organisation" .Organisation "Email" .Data.Email)}}</p>
+
+<p>{{T "email.document_share.instructions"}}</p>
+
+<div style="text-align: center; margin: 30px 0;">
+    <a href="{{.Data.ShareLink}}"
+       style="background-color: #4F46E5;
+              color: white;
+              padding: 14px 40px;
+              text-decoration: none;
+              border-radius: 6px;
+              display: inline-block;
+              font-weight: bold;">
+        {{T "email.document_share.cta_button"}}
+    </a>
+</div>
+
+<div style="background: #DBEAFE; padding: 15px; border-left: 4px solid #3B82F6; border-radius: 4px; margin: 20px 0;">
+    <p style="margin: 0;">
+        🔑 <strong>{{T "email.document_share.otp_notice_title"}}</strong>
+        {{T "email.document_share.otp_notice_text"}}
+    </p>
+</div>
+
+<div style="background: #FEF3C7; padding: 15px; border-left: 4px solid #F59E0B; border-radius: 4px; margin: 20px 0;">
+    <p style="margin: 0;">
+        ⏱️ <strong>{{T "email.document_share.warning_title"}}</strong>
+        {{T "email.document_share.warning_text" (dict "ValidityDays" .Data.ValidityDays)}}
+    </p>
+</div>
+
+<p>{{T "email.document_share.not_requested"}}</p>
+
+<hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+
+<p style="color: #666; font-size: 0.9em;">
+    {{T "email.document_share.button_not_working"}}<br>
+    <a href="{{.Data.ShareLink}}" style="color: #4F46E5; word-break: break-all;">{{.Data.ShareLink}}</a>
+</p>
+
+<p style="color: #999; font-size: 0.8em;">
+    {{T "email.document_share.footer" (dict "Organisation" .Organisation "BaseURL" .Data.BaseURL)}}
+</p>
+{{end}}

--- a/backend/templates/document_share.txt.tmpl
+++ b/backend/templates/document_share.txt.tmpl
@@ -1,0 +1,20 @@
+{{define "content"}}
+{{T "email.document_share.title"}}
+
+{{T "email.document_share.greeting"}}
+
+{{T "email.document_share.intro" (dict "Organisation" .Organisation "Email" .Data.Email)}}
+
+{{T "email.document_share.instructions"}}
+
+{{.Data.ShareLink}}
+
+{{T "email.document_share.otp_notice_title"}} {{T "email.document_share.otp_notice_text"}}
+
+{{T "email.document_share.warning_title"}} {{T "email.document_share.warning_text" (dict "ValidityDays" .Data.ValidityDays)}}
+
+{{T "email.document_share.not_requested"}}
+
+---
+{{T "email.document_share.footer" (dict "Organisation" .Organisation "BaseURL" .Data.BaseURL)}}
+{{end}}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.34.0
-	golang.org/x/text v0.33.0
+	golang.org/x/text v0.34.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -41,6 +41,7 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
+	golang.org/x/crypto v0.48.0 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/mail.v2 v2.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -120,12 +120,17 @@ go.opentelemetry.io/otel/metric v1.37.0 h1:mvwbQS5m0tbmqML4NqK+e3aDiO02vsf/Wgbsd
 go.opentelemetry.io/otel/metric v1.37.0/go.mod h1:04wGrZurHYKOc+RKeye86GwKiTb9FKm1WHtO+4EVr2E=
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
 golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=
 golang.org/x/text v0.33.0/go.mod h1:LuMebE6+rBincTi9+xWTY8TztLzKHc/9C1uBCG27+q8=
+golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
+golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=
 gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gGKlE2+asNV9m7xrywl36YYNnBG5ZQ0r/BOOxqPpmk=
 gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Why

Ackify produces reports for clients who need to read and acknowledge them. Currently there's no way to share a private document with a client who doesn't have an account, without exposing them through a public link or onboarding them through full SSO.

We need a lightweight, secure sharing mechanism that:
- Doesn't require the client to create an account
- Keeps the document private (not just "anyone with the link")
- Lets the admin control and revoke access
- Works with rotating clients (SSO onboarding is too heavy)

## What

A new **API-driven document sharing feature** that combines magic links with one-time password (OTP) verification. **Backend only — no UI changes.**

### User flow

1. **Admin** calls the API to share a document with a client email
2. System returns the **OTP** to the admin (shown once, never stored in cleartext) and emails the **magic link** to the client
3. Admin communicates the OTP to the client through a separate channel (phone, SMS, in-person)
4. **Client** clicks the magic link → sees an OTP prompt
5. Client enters the OTP → gets a session and is redirected to the document
6. The link remains usable (multi-use) as long as it's not expired or revoked
7. **Admin** can list all shares for a document and revoke any of them

### Security model

| Layer | Protection |
|-------|-----------|
| **Link alone** | Not enough — OTP is required |
| **OTP** | 6-digit, hashed with **bcrypt**, never in emails, never stored in cleartext |
| **Brute force** | 5 attempt limit, then permanent lockout |
| **Error messages** | Generic — never reveal if token is revoked/locked/expired |
| **Token exposure** | Admin listing endpoint does NOT return the magic link token value |
| **Access control** | Create/list/revoke endpoints require admin authentication |
| **Validity** | Configurable 1–90 days per share, default 7 |

## How

### Architecture

Built on top of the existing `magic_link_tokens` table and [MagicLinkService](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/application/services/magic_link_service.go#48-60), extending them with OTP and revocation capabilities:

```mermaid
graph TD
    A[Admin Handler] -->|CreateDocumentShareLink| B[AuthProvider Interface]
    B --> C[Dynamic Provider]
    C --> D[MagicLinkService]
    D --> E[MagicLinkRepository]
    E --> F[(magic_link_tokens table)]
    D --> G[Email Sender]

    H[Public Auth Handler] -->|ValidateDocumentShareToken| B
    H -->|VerifyDocumentShareOTP| B

    style A fill:#f9a825
    style H fill:#66bb6a
```

### New API endpoints

| Method | Path | Auth | Purpose |
|--------|------|------|---------|
| `POST` | `/api/v1/admin/documents/{docId}/share` | Admin | Create share → `{otp, link}` |
| `GET` | `/api/v1/admin/documents/{docId}/shares` | Admin | List shares for a document |
| `DELETE` | `/api/v1/admin/documents/{docId}/share/{tokenId}` | Admin | Revoke a share |
| `GET` | `/api/v1/auth/document-share/verify?token=...` | Public | Validate token → `{status: "otp_required"}` |
| `POST` | `/api/v1/auth/document-share/verify-otp` | Public | Submit OTP → session cookie + `{redirect_to}` |

### Database changes

Migration `0020_add_document_share_otp`:

```sql
ALTER TABLE magic_link_tokens
  ADD COLUMN otp_hash TEXT,              -- bcrypt hash of 6-digit OTP
  ADD COLUMN otp_attempts INT DEFAULT 0, -- failed OTP attempts counter
  ADD COLUMN otp_max_attempts INT DEFAULT 5,
  ADD COLUMN revoked_at TIMESTAMPTZ,     -- NULL = active
  ADD COLUMN shared_by TEXT;             -- admin email who created the share
```

All columns are nullable/have defaults → **zero impact on existing rows**.

## Files changed

### New files

| File | Lines | Purpose |
|------|-------|---------|
| `migrations/0020_add_document_share_otp.up.sql` | 25 | Schema migration |
| `migrations/0020_add_document_share_otp.down.sql` | 14 | Rollback |
| [internal/presentation/api/admin/share_handler.go](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/presentation/api/admin/share_handler.go) | 125 | Admin HTTP handlers |
| [templates/document_share.html.tmpl](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/templates/document_share.html.tmpl) | 49 | Email template (HTML) |
| [templates/document_share.txt.tmpl](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/templates/document_share.txt.tmpl) | 11 | Email template (text) |

### Modified files

| File | What changed |
|------|-------------|
| [pkg/models/magic_link.go](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/pkg/models/magic_link.go) | +5 OTP fields, [IsOTPLocked()](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/pkg/models/magic_link.go#53-57), updated [IsValid()](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/pkg/models/magic_link.go#35-52) |
| [internal/infrastructure/database/magic_link_repository.go](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/infrastructure/database/magic_link_repository.go) | +3 methods ([IncrementOTPAttempts](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/application/services/magic_link_service.go#28-29), [RevokeToken](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/infrastructure/database/magic_link_repository.go#239-261), [ListByDocAndPurpose](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/infrastructure/database/magic_link_repository.go#262-326)), updated [CreateToken](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/infrastructure/database/magic_link_repository.go#24-50)/[GetByToken](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/application/services/magic_link_service.go#22-23), fixed [DeleteExpired](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/application/services/magic_link_service.go#24-25) |
| [internal/application/services/magic_link_service.go](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/application/services/magic_link_service.go) | +5 methods, removed custom [min()](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/presentation/api/shared/middleware_test.go#147-150) that shadowed Go 1.21+ builtin |
| [pkg/providers/interfaces.go](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/pkg/providers/interfaces.go) | +5 methods on [AuthProvider](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/pkg/providers/interfaces.go#26-78), +[DocumentShareInfo](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/pkg/providers/interfaces.go#107-118) struct |
| [pkg/web/auth/dynamic_provider.go](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/pkg/web/auth/dynamic_provider.go) | Implemented 5 new methods |
| [internal/presentation/api/auth/handler.go](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/presentation/api/auth/handler.go) | +2 public handlers |
| [internal/presentation/api/router.go](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/presentation/api/router.go) | +5 routes |
| [locales/en.json](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/locales/en.json) | +14 i18n keys |
| [locales/fr.json](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/locales/fr.json) | +14 i18n keys |
| [locales/de.json](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/locales/de.json) | +14 i18n keys |
| [locales/es.json](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/locales/es.json) | +14 i18n keys |
| [locales/it.json](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/locales/it.json) | +14 i18n keys |
| [internal/presentation/api/auth/handler_test.go](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/presentation/api/auth/handler_test.go) | +5 mock methods |
| [internal/presentation/api/shared/middleware.go](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/presentation/api/shared/middleware.go) | Exempt `/document-share/verify` from strict API CSP |

### UI & Styling
- Built a standalone HTML OTP page directly served by the backend (zero frontend deployment required)
- Styled using Vanilla CSS to match the exact Ackify login theme (gradient, rounded corners, clean Google Fonts, lock icon)
- Fully responsive with auto-advance digit boxes, copy-paste support, and spinner animations
- Implemented a tailored, secure Content Security Policy (CSP) allowing only inline styles and specific font domains, while enabling `connect-src 'self'` for the frontend API fetch.

### Dependencies

- `golang.org/x/crypto` bumped (already indirect dependency, now used directly for `bcrypt`)

## Side effects on existing code

> [!IMPORTANT]
> Carefully analyzed — **no existing behavior is affected**.

| Concern | Analysis | Verdict |
|---------|----------|---------|
| [IsValid()](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/pkg/models/magic_link.go#35-52) change on login/reminder tokens | New checks: `RevokedAt` (NULL → passes), [IsOTPLocked()](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/pkg/models/magic_link.go#53-57) (OTPMaxAttempts=5 default, OTPAttempts=0 → false), `UsedAt` guard has `Purpose != "document_share"` → login/reminder still single-use | Safe |
| [DeleteExpired](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/application/services/magic_link_service.go#24-25) cleanup cron | Added `AND purpose != 'document_share'` to unused-token cleanup. Without this, multi-use document shares (where `used_at` stays NULL) would be deleted after 7 days even if valid for 90 days. Login/reminder tokens unaffected. | Fixed |
| [CreateToken](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/infrastructure/database/magic_link_repository.go#24-50) / [GetByToken](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/application/services/magic_link_service.go#22-23) SQL changes | New columns added to INSERT/SELECT. Old tokens have NULL/default values for new columns → queries work identically. | Safe |
| [AuthProvider](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/pkg/providers/interfaces.go#26-78) interface | 5 new methods. Any external implementation would fail to compile. This is a **compile-time** break, never a silent runtime failure. CE has one implementation ([dynamic_provider.go](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/pkg/web/auth/dynamic_provider.go)) which is updated. |  Interface change |

## Testing

### Unit tests
- **18/18 pass** in [auth/handler_test.go](file:///c:/Users/illan.makhloufi/Documents/ackify/ackify-ce/backend/internal/presentation/api/auth/handler_test.go) (existing + updated mocks)

### Live end-to-end test (against real PostgreSQL)

| Step | Input | Result |
|------|-------|--------|
| Valid token → verify page | `GET /verify?token=<real>` | `{"status":"otp_required"}`  |
| Wrong OTP | `POST /verify-otp {otp:"000000"}` | `{"error":"Invalid or expired link or access code"}`  |
| Correct OTP | `POST /verify-otp {otp:"546947"}` | `{"redirect_to":"/?doc=test-document-001"}`  |
| Re-use token | `GET /verify?token=<same>` | `{"status":"otp_required"}`  (multi-use works) |
| Fake token | `GET /verify?token=fake` | `{"error":"Invalid or expired link"}`  |

### Build verification
- `go build ./backend/...` — clean compilation, zero warnings

## What's next (not in this PR)

- **Frontend**: Admin share management panel